### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "privateca",
     "name_pretty": "Private Certificate Authority",
     "product_documentation": "https://cloud.google.com/certificate-authority-service",
-    "client_documentation": "https://googleapis.dev/python/privateca/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/privateca/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ within infrastructure and cloud native applications.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-private-ca.svg
    :target: https://pypi.org/project/google-cloud-private-ca/
 .. _Certificate Authority Service: https://cloud.google.com/certificate-authority-service
-.. _Client Library Documentation: https://googleapis.dev/python/privateca/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/privateca/latest
 .. _Product Documentation:  https://cloud.google.com/certificate-authority-service/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.