### PR TITLE
fix: Use unittest.mock if available

### DIFF
--- a/tests/unit/gapic/privateca_v1/test_certificate_authority_service.py
+++ b/tests/unit/gapic/privateca_v1/test_certificate_authority_service.py
@@ -39,7 +39,11 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from google.type import expr_pb2  # type: ignore
 import grpc
 from grpc.experimental import aio
-import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 import pytest
 

--- a/tests/unit/gapic/privateca_v1beta1/test_certificate_authority_service.py
+++ b/tests/unit/gapic/privateca_v1beta1/test_certificate_authority_service.py
@@ -39,7 +39,10 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from google.protobuf import wrappers_pb2  # type: ignore
 import grpc
 from grpc.experimental import aio
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 import pytest
 


### PR DESCRIPTION
New versions of Python 3 have `unittest.mock` to replace the deprecated
`mock` module. Attempt to import `unittest.mock` if it is available.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #231 🦕
