### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [1.3.1](https://github.com/googleapis/python-security-private-ca/compare/v1.3.0...v1.3.1) (2022-05-05)
+## [1.3.1](https://github.com/googleapis/python-security-private-ca/compare/v1.3.0...v1.3.1) (2022-05-05)
 
 
 ### Documentation
@@ -14,7 +14,7 @@
 
 * Add `skip_grace_period` flag to DeleteCertificateAuthority API ([#197](https://github.com/googleapis/python-security-private-ca/issues/197)) ([3119d1a](https://github.com/googleapis/python-security-private-ca/commit/3119d1a55701ddf09d3a1351fafab731bf2b4cf1))
 
-### [1.2.4](https://github.com/googleapis/python-security-private-ca/compare/v1.2.3...v1.2.4) (2022-03-05)
+## [1.2.4](https://github.com/googleapis/python-security-private-ca/compare/v1.2.3...v1.2.4) (2022-03-05)
 
 
 ### Bug Fixes
@@ -22,7 +22,7 @@
 * **deps:** require google-api-core>=1.31.5, >=2.3.2 ([#192](https://github.com/googleapis/python-security-private-ca/issues/192)) ([3b4a00b](https://github.com/googleapis/python-security-private-ca/commit/3b4a00b60a35c99780e7090191553c622b353055))
 * **deps:** require proto-plus>=1.15.0 ([3b4a00b](https://github.com/googleapis/python-security-private-ca/commit/3b4a00b60a35c99780e7090191553c622b353055))
 
-### [1.2.3](https://github.com/googleapis/python-security-private-ca/compare/v1.2.2...v1.2.3) (2022-02-26)
+## [1.2.3](https://github.com/googleapis/python-security-private-ca/compare/v1.2.2...v1.2.3) (2022-02-26)
 
 
 ### Documentation
@@ -30,7 +30,7 @@
 * add generated snippets ([#180](https://github.com/googleapis/python-security-private-ca/issues/180)) ([35054f8](https://github.com/googleapis/python-security-private-ca/commit/35054f85db310ac3b0e6393557e42f40d0018995))
 * **samples:** add template/monitoring samples ([#174](https://github.com/googleapis/python-security-private-ca/issues/174)) ([9fbd3e1](https://github.com/googleapis/python-security-private-ca/commit/9fbd3e11b5f5d6370ffbd1702dd18c8774dc41be))
 
-### [1.2.2](https://github.com/googleapis/python-security-private-ca/compare/v1.2.1...v1.2.2) (2022-02-03)
+## [1.2.2](https://github.com/googleapis/python-security-private-ca/compare/v1.2.1...v1.2.2) (2022-02-03)
 
 
 ### Features
@@ -55,7 +55,7 @@
 * mark CaPool.lifetime as IMMUTABLE ([#177](https://github.com/googleapis/python-security-private-ca/issues/177)) ([259f1c9](https://github.com/googleapis/python-security-private-ca/commit/259f1c9e354b33140ff13a8ddb1b503ec810630b))
 * **samples:** add sample to filter certificates ([#160](https://github.com/googleapis/python-security-private-ca/issues/160)) ([a0ae8b2](https://github.com/googleapis/python-security-private-ca/commit/a0ae8b2c9139bee84c2da645d4456b97066eff74))
 
-### [1.2.1](https://www.github.com/googleapis/python-security-private-ca/compare/v1.2.0...v1.2.1) (2021-11-02)
+## [1.2.1](https://www.github.com/googleapis/python-security-private-ca/compare/v1.2.0...v1.2.1) (2021-11-02)
 
 
 ### Bug Fixes
@@ -83,21 +83,21 @@
 
 * add context manager support in client ([#131](https://www.github.com/googleapis/python-security-private-ca/issues/131)) ([eb9fc8b](https://www.github.com/googleapis/python-security-private-ca/commit/eb9fc8b1a324505418ece9636e91d844e11845de))
 
-### [1.0.6](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.5...v1.0.6) (2021-09-30)
+## [1.0.6](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.5...v1.0.6) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([f86ec89](https://www.github.com/googleapis/python-security-private-ca/commit/f86ec89f3c4537556188064606be005ee7feb056))
 
-### [1.0.5](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.4...v1.0.5) (2021-09-24)
+## [1.0.5](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.4...v1.0.5) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([49b5c9a](https://www.github.com/googleapis/python-security-private-ca/commit/49b5c9ae54c594abf1a8158506e2a1ddb6dce67d))
 
-### [1.0.4](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.3...v1.0.4) (2021-08-10)
+## [1.0.4](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.3...v1.0.4) (2021-08-10)
 
 
 ### Documentation
@@ -109,7 +109,7 @@
 
 * release as 1.0.4 ([#100](https://www.github.com/googleapis/python-security-private-ca/issues/100)) ([47fb407](https://www.github.com/googleapis/python-security-private-ca/commit/47fb4075db02e5c3eaf4f25f3d032a6c2514afce))
 
-### [1.0.3](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.2...v1.0.3) (2021-07-29)
+## [1.0.3](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.2...v1.0.3) (2021-07-29)
 
 
 ### Bug Fixes
@@ -127,14 +127,14 @@
 
 * release as 1.0.3 ([#92](https://www.github.com/googleapis/python-security-private-ca/issues/92)) ([6026929](https://www.github.com/googleapis/python-security-private-ca/commit/6026929efe36ecec40afbc442f09df609b7c42a8))
 
-### [1.0.2](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.1...v1.0.2) (2021-07-20)
+## [1.0.2](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.1...v1.0.2) (2021-07-20)
 
 
 ### Bug Fixes
 
 * **deps:** pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions ([#83](https://www.github.com/googleapis/python-security-private-ca/issues/83)) ([cd5390c](https://www.github.com/googleapis/python-security-private-ca/commit/cd5390cf5fff50419b000c71431d8ede0de35833))
 
-### [1.0.1](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.0...v1.0.1) (2021-07-16)
+## [1.0.1](https://www.github.com/googleapis/python-security-private-ca/compare/v1.0.0...v1.0.1) (2021-07-16)
 
 
 ### Bug Fixes
@@ -189,7 +189,7 @@
 * add async client to %name_%version/init.py ([c4c8624](https://www.github.com/googleapis/python-security-private-ca/commit/c4c862426fb5b7b931dd0de4d26d1ac27ce05f1a))
 * **deps:** add packaging requirement ([#56](https://www.github.com/googleapis/python-security-private-ca/issues/56)) ([5877dda](https://www.github.com/googleapis/python-security-private-ca/commit/5877dda559311e87de8f9f06f8174a0e1d4c62bc))
 
-### [0.1.1](https://www.github.com/googleapis/python-security-private-ca/compare/v0.1.0...v0.1.1) (2020-10-02)
+## [0.1.1](https://www.github.com/googleapis/python-security-private-ca/compare/v0.1.0...v0.1.1) (2020-10-02)
 
 
 ### Documentation


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.