### PR TITLE
chore: Prepare for mono repository migration

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -35,16 +35,7 @@ for library in s.get_staging_dirs(default_version):
     if clean_up_generated_samples:
         shutil.rmtree("samples/generated_samples", ignore_errors=True)
         clean_up_generated_samples = False
-
-    # Remove replacement once this repository has migrated to google-cloud-python
-    s.replace(
-        library / "setup.py",
-        """url = \"https://github.com/googleapis/python-private-ca\"""",
-        """url = \"https://github.com/googleapis/python-security-private-ca\"""",
-    )
-
     s.move([library], excludes=["**/gapic_version.py"])
-
 s.remove_staging_dirs()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Remove replacement in owlbot.py which will be obsolete in the monorepo

Remove replacement in owlbot.py which will be obsolete in the monorepo as the reason for the customization was due to the discrepancy between the package name `google-cloud-private-ca` and the repository name `python-security-private-ca`. In the monorepo, we will have package `google-cloud-private-ca` which is predictable.

